### PR TITLE
MSEDO-200: Correct to plural menu name "Regimes Terapeuticos"

### DIFF
--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -11,7 +11,7 @@
         "notice": "Notice",
         "drug": "Drug",
         "treatment": "Treatment",
-        "therapeuticRegime": "Therapeutic Regime",
+        "therapeuticRegime": "Therapeutic Regimes",
         "document": "Document",
         "content": "Content",
         "outcome": "Outcome",

--- a/src/main/webapp/i18n/pt-pt/global.json
+++ b/src/main/webapp/i18n/pt-pt/global.json
@@ -11,7 +11,7 @@
         "notice": "Observação",
         "drug": "Medicamento",
         "treatment": "Tratamento",
-        "therapeuticRegime": "Regime Terapêutico",
+        "therapeuticRegime": "Regimes Terapêuticos",
         "document": "Documento",
         "content": "Conteúdo",
         "outcome": "PROM",


### PR DESCRIPTION
Updated translation to "Regimes Terapêuticos"
![image](https://user-images.githubusercontent.com/3706415/99845239-3c1e1980-2b6c-11eb-8841-460c490665f9.png)
